### PR TITLE
Remove announcement for Automationeers meeting

### DIFF
--- a/scripts/cron-jobs.coffee
+++ b/scripts/cron-jobs.coffee
@@ -2,15 +2,15 @@
 #   Sets up cron jobs for webqabot.
 #
 
-PropertiesReader = require 'properties-reader'
-properties = PropertiesReader('resources/responses.properties')
-
-module.exports = (robot) ->
-
-  cronJob = require("cron").CronJob
-
-  event = () ->
-    if new Date().getDate() < 7
-      robot.emit 'announceEvent', 'in 15 minutes', 'Automationeers Assemble'
-
-  new cronJob('45 12 * * 3', event, null, true, 'America/Los_Angeles')
+# PropertiesReader = require 'properties-reader'
+# properties = PropertiesReader('resources/responses.properties')
+#
+# module.exports = (robot) ->
+#
+#   cronJob = require("cron").CronJob
+#
+#   event = () ->
+#     if new Date().getDate() < 7
+#       robot.emit 'announceEvent', 'in 15 minutes', 'Automationeers Assemble'
+#
+#   new cronJob('45 12 * * 3', event, null, true, 'America/Los_Angeles')


### PR DESCRIPTION
This event no longer occurs on a regular schedule. Commenting out the reminder instead of removing it so it can be used as a reference for future schedules.